### PR TITLE
使用静态变量传递图片列表，避免TransactionTooLargeException问题

### DIFF
--- a/library/src/main/java/cn/bingoogolapple/photopicker/activity/BGAPhotoPickerPreviewActivity.java
+++ b/library/src/main/java/cn/bingoogolapple/photopicker/activity/BGAPhotoPickerPreviewActivity.java
@@ -50,6 +50,8 @@ public class BGAPhotoPickerPreviewActivity extends BGAPPToolbarActivity implemen
     private static final String EXTRA_CURRENT_POSITION = "EXTRA_CURRENT_POSITION";
     private static final String EXTRA_IS_FROM_TAKE_PHOTO = "EXTRA_IS_FROM_TAKE_PHOTO";
 
+    public static ArrayList<String> sPreviewPhotos = new ArrayList<>();
+
     private TextView mTitleTv;
     private TextView mSubmitTv;
     private BGAHackyViewPager mContentHvp;
@@ -101,7 +103,7 @@ public class BGAPhotoPickerPreviewActivity extends BGAPPToolbarActivity implemen
          * 当前预览的图片路径集合
          */
         public IntentBuilder previewPhotos(ArrayList<String> previewPhotos) {
-            mIntent.putStringArrayListExtra(EXTRA_PREVIEW_PHOTOS, previewPhotos);
+            BGAPhotoPickerPreviewActivity.sPreviewPhotos = previewPhotos;
             return this;
         }
 
@@ -208,7 +210,7 @@ public class BGAPhotoPickerPreviewActivity extends BGAPPToolbarActivity implemen
             mSelectedPhotos = new ArrayList<>();
         }
 
-        ArrayList<String> previewPhotos = getIntent().getStringArrayListExtra(EXTRA_PREVIEW_PHOTOS);
+        ArrayList<String> previewPhotos = sPreviewPhotos;
         if (TextUtils.isEmpty(previewPhotos.get(0))) {
             // 从BGAPhotoPickerActivity跳转过来时，如果有开启拍照功能，则第0项为""
             previewPhotos.remove(0);


### PR DESCRIPTION
当图片过多的时候，使用Intent传递不了这么大的数据，可以使用静态变量来传递，在简单场景下够用了